### PR TITLE
Add AVX requirement for pr57275 32-bit test

### DIFF
--- a/requirements/pr57275.c.gcc-target-test-32.json
+++ b/requirements/pr57275.c.gcc-target-test-32.json
@@ -1,0 +1,3 @@
+{
+  "HostFeatures": ["AVX"]
+}


### PR DESCRIPTION
Will be used for filtering this test out on non-AVX capable systems